### PR TITLE
Use new redis image

### DIFF
--- a/addok-redis/Dockerfile
+++ b/addok-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:4
+FROM redis:6.0.10
 
 COPY redis.conf /usr/local/etc/redis/redis.conf
 


### PR DESCRIPTION
Ceci est un petit fix pour l'utilisation de docker-compose avec un mac m1. Je n'ai pas testé avec d'autres OS.